### PR TITLE
Alteração no numero dos pedidos

### DIFF
--- a/main.py
+++ b/main.py
@@ -1235,7 +1235,8 @@ class SistemaPedidos:
             else:
                 self.cursor.execute("SELECT COUNT(*) FROM pedidos")
                 total_registros = self.cursor.fetchone()[0] or 0
-                numero_pedido = f"ORC-{total_registros+1:04d}"
+                data = datetime.now().strftime("%Y%m%d")
+                numero_pedido = f"ORC-{data}-{total_registros+1:03d}"
                 self.label_numero_orc.config(text=numero_pedido)
 
             data_pedido = datetime.now().strftime('%Y-%m-%d %H:%M:%S')
@@ -1507,7 +1508,7 @@ class SistemaPedidos:
             try:
                 
                 logo = Image("logo.png", width=120, height=30)  # ajuste conforme a sua logo
-                logo.hAlign = 'center'
+                logo.hAlign = 'CENTER'
                 elementos.append(logo)
             except:
                 pass
@@ -1517,7 +1518,7 @@ class SistemaPedidos:
             elementos.append(titulo)
             elementos.append(Spacer(1, 6))
 
-            num_orc = Paragraph(f"<para align='center'><font size=12>Orçamento nº <b>{numero_pedido}</b></font></para>",
+            num_orc = Paragraph(f"<para align='center'><font size=12>Nº <b>{numero_pedido}</b></font></para>",
                                 estilos['Normal'])
             elementos.append(num_orc)
             elementos.append(Spacer(1, 20))


### PR DESCRIPTION
### 💡 Descrição

Este PR altera o formato de geração do número do pedido (`numero_pedido`) para um padrão mais profissional e rastreável, incorporando a **data completa (YYYYMMDD)** ao código.

### 🧩 Alteração principal

Antes:

```python
numero_pedido = f"ORC-{total_registros+1:04d}"
```

Depois:

```python
from datetime import datetime
data = datetime.now().strftime("%Y%m%d")
numero_pedido = f"ORC-{data}-{total_registros+1:03d}"
```

### ✅ Resultado esperado

Agora os números de pedido seguem o formato:

```
ORC-20251007-001
```

Isso facilita a identificação da **data de criação** e melhora o controle sequencial, mantendo a compatibilidade com o sistema existente.

### 🔍 Testes realizados

* Criação de novos pedidos em sequência.
* Validação do formato gerado.
* Conferência da persistência no banco e exibição correta no `label_numero_orc`.

### 🧾 Observação

Nenhuma alteração estrutural foi feita no banco de dados — apenas no formato exibido e armazenado do número de pedido.
