### PR TITLE
Ajusta ordem dos campos no cadastro de empresas para exibir CEP antes…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
 openpyxl
 reportlab
 ttkbootstrap
+requests


### PR DESCRIPTION
### 🧩 Descrição

Este PR realiza uma melhoria no formulário de **cadastro e edição de empresas** no `main.py`, alterando a **ordem dos campos** para que o **CEP apareça antes do Endereço**, e adicionando a **busca automática de endereço via API ViaCEP**.

---

### 🚀 Alterações Principais

* Campo **CEP** movido para antes do **Endereço** no formulário de empresas.
* Adicionada integração com o método existente `buscar_cep()`, acionada automaticamente ao perder o foco do campo de CEP.
* Campos de **Endereço**, **Cidade** e **Estado** passam a ser preenchidos automaticamente conforme o CEP informado.
* Ajustes menores de layout e grid para manter responsividade e consistência visual.

---

### 🧠 Benefícios

* Maior **intuitividade** para o usuário (CEP aparece na posição esperada).
* **Redução de erros de digitação** no endereço.
* **Aumento da produtividade** no cadastro e atualização de empresas.

---

### 🧪 Testes Realizados

* Testado cadastro de nova empresa com CEP válido (preenchimento automático OK).
* Testado edição de empresa existente (dados carregados corretamente).
* Testado CEP inválido e não encontrado (mensagem de aviso exibida corretamente).
* Compatível com a função `buscar_cep()` já presente no código.

---

### 🧱 Detalhes Técnicos

Branch: `feature/ajuste-cep-antes-endereco`
Arquivo alterado: `main.py`
Método atualizado: `abrir_formulario_empresa`

---

### ✅ Checklist

* [x] Campo CEP antes do Endereço
* [x] Busca automática de endereço ao sair do campo
* [x] Mensagens de erro tratadas
* [x] Testado em ambiente local
* [x] Código compatível com SQLite e Tkinter

---

💡 **Sugestão futura:** adicionar botão "Buscar CEP" ao lado do campo, como alternativa ao evento de foco.
