### PR TITLE
Projetos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,162 @@
+# Changelog
+
+Todas as mudanças notáveis neste projeto serão documentadas aqui.
+
+O formato segue o padrão [Keep a
+Changelog](https://keepachangelog.com/pt-BR/1.0.0/).
+
+## \[Unreleased\]
+
+## [1.4.1] - 09/Out/25
+
+### Changed
+
+* **Removida a exibição dos IDs** nas abas **Empresas** e **Produtos**, mantendo-os apenas para uso interno.
+* **`carregar_empresas()`** e **`editar_empresa()`** ajustados para uso de `tags` (armazenando o ID de forma oculta).
+* **`carregar_produtos()`** atualizado para alinhar corretamente as colunas e remover o campo `id` do `SELECT`.
+* Layout mais limpo e consistente entre todas as abas do sistema.
+
+### Fixed
+
+* Corrigido desalinhamento de colunas causado pela presença do ID oculto no `SELECT`.
+* Corrigido bug menor ao abrir o formulário de edição de empresa quando a coluna ID era removida da tabela.
+
+---
+
+## [1.4.0] - 07/Out/25
+
+### Added
+- **Cadastro de Empresas Emissoras**:
+  - Nova aba para gerenciar empresas vinculadas aos orçamentos.
+  - Campos de nome, CNPJ, endereço, e-mail e telefone.
+  - Upload de **logos em PNG** com pré-visualização na interface.
+  - Armazenamento automático da logo na pasta `/logos`.
+
+- **Integração de Empresas com Orçamentos**:
+  - Cada orçamento agora pode estar vinculado a uma empresa emissora.
+  - Dados da empresa (nome, CNPJ, logo, etc.) são exibidos no PDF gerado.
+
+- **Diferenciação visual entre “Novo” e “Edição de Orçamento”**:
+  - Faixa colorida no topo da aba indicando o modo atual:
+    - 🟢 Verde para “Novo Orçamento”
+    - 🟠 Laranja para “Edição de Orçamento”
+  - Botão principal muda texto e cor conforme o modo.
+  - Campos de **Cliente** e **Empresa** são bloqueados durante edição.
+
+- **Layout PDF Padronizado (multiempresa)**:
+  - Cabeçalho fixo com logo e informações da empresa emissora.
+  - Estrutura universal para todas as empresas do grupo.
+  - Melhor espaçamento, margens consistentes e total destacado.
+  - Nome de arquivo padronizado com data e hora (`orcamento_<num>_<data>.pdf`).
+
+### Changed
+- Função `gerar_pdf_orcamento` totalmente revisada para suportar múltiplas empresas.
+- Imports reorganizados (evitando conflitos entre `Image` do Pillow, ReportLab e OpenPyXL).
+- Melhor tratamento para campos ausentes (exibe “–” quando não há dados).
+- Botão de salvar/atualizar orçamento agora reflete automaticamente o modo ativo.
+- Títulos e rótulos atualizados para maior clareza visual.
+
+### Fixed
+- Corrigido erro ao gerar PDF com empresa sem logo.
+- Corrigido bug em `finalizar_pedido` que não atualizava interface após salvar.
+- Ajustada proporção de logos no PDF (largura fixa, altura proporcional).
+
+---
+
+
+
+## [1.3.1] - 06/Out/25
+
+### Added
+- Centralização visual aplicada a todas as tabelas (`Treeview`) do sistema.
+
+### Changed
+- Colunas das abas **Clientes**, **Produtos**, **Consultar Orçamentos**, **Itens do Orçamento** e **Visualização de Orçamento (popup)** agora exibem o conteúdo centralizado.
+- Melhoria geral na legibilidade e alinhamento das informações nas tabelas.
+
+---
+
+## \[1.3.0\] - 02/Out/25
+
+### Added
+
+-   Nova janela **popup** para cadastro/edição de clientes (mais
+    intuitiva).
+
+### Changed
+
+-   Aba **Clientes** simplificada:
+    -   Removido formulário fixo acima da tabela.
+    -   Mantidos apenas os botões de ação no topo (**Adicionar**,
+        **Editar**, **Excluir**, **Importar Arquivo**) e a lista de
+        clientes abaixo.
+    -   Estilização dos botões com `ttkbootstrap` (`success`, `info`,
+        `danger`, `warning`).
+-   `editar_cliente` atualizado para abrir o formulário popup, sem
+    depender de `self.cliente_entries`.
+
+### Removed
+
+-   Formulário embutido de clientes na aba principal (substituído por
+    popup).
+
+------------------------------------------------------------------------
+
+## \[1.2.0\] - 02/Out/25
+
+### Added
+
+-   Botão de **Exportar PDF** na aba de Orçamentos.
+
+### Changed
+
+-   Interface da aba **Orçamentos** modernizada com `ttkbootstrap`
+    (layout mais moderno e intuitivo).
+-   Textos dos botões padronizados para ficarem mais claros para o
+    usuário.
+-   Melhorias no fluxo de edição de orçamentos.
+
+### Removed
+
+-   Geração automática de PDF ao salvar/atualizar orçamentos (removida
+    para evitar criação de múltiplos arquivos desnecessários a cada
+    alteração).
+
+------------------------------------------------------------------------
+
+## \[1.1.0\] - 01/Out/25
+
+### Added
+
+-   Novos filtros para consulta de orçamentos.
+-   Ajustes de tela e alterações no banco de dados.
+
+### Changed
+
+-   Refinamentos na exportação e relatórios.
+-   Ajustes finais em telas e lógicas.
+
+------------------------------------------------------------------------
+
+## \[1.0.1\] - 30/Set/25
+
+### Added
+
+-   Função de importar produtos a partir de arquivo.
+
+### Changed
+
+-   Customização inicial dos PDFs.
+-   Correções gerais no sistema.
+
+------------------------------------------------------------------------
+
+## \[1.0.0\] - 29/Set/25
+
+### Added
+
+-   Versão inicial do **Sistema de Orçamentos** com:
+    -   Cadastro de clientes e produtos.
+    -   Cadastro e edição de orçamentos.
+    -   Exportação de orçamentos para Excel.
+    -   Geração de PDF simples.

--- a/readme.md
+++ b/readme.md
@@ -1,24 +1,31 @@
-# Sistema de Orçamentos
+# 💼 Sistema de Orçamentos
 
-Aplicação em Python com Tkinter e SQLite para cadastro de clientes, produtos e geração de orçamentos em PDF e Excel.
+Aplicação em **Python (Tkinter + SQLite)** para cadastro de clientes, produtos e geração de orçamentos em **PDF** e **Excel**.
 
-## Funcionalidades
+---
 
-- Cadastro, edição, exclusão e importação de **clientes** e **produtos**.
-- Criação e edição de **orçamentos** com controle de status: *Em Aberto*, *Aprovado*, *Cancelado*, *Rejeitado*.
-- Consulta avançada de orçamentos por filtros (número, cliente, representante, status e período).
-- Exportação de orçamentos em **PDF padronizado** e **Excel (.xlsx)**.
-- Banco de dados SQLite (`pedidos.db`) gerado automaticamente.
+## 🚀 Funcionalidades
 
-## Requisitos
+- Cadastro, edição, exclusão e importação de **clientes** e **produtos**.  
+- Criação e edição de **orçamentos** com controle de status:  
+  *Em Aberto*, *Aprovado*, *Cancelado*, *Rejeitado*.  
+- Consulta avançada de orçamentos por filtros (**número**, **cliente**, **representante**, **status**, **período**).  
+- Exportação de orçamentos em **PDF padronizado** e **Excel (.xlsx)**.  
+- Banco de dados **SQLite (`pedidos.db`)** gerado automaticamente.  
 
-- Python 3.10+
+---
+
+## 🧩 Requisitos
+
+- Python **3.10+**
 - Dependências listadas em `requirements.txt`:
   - `openpyxl`
   - `reportlab`
   - `ttkbootstrap`
 
-## Instalação
+---
+
+## ⚙️ Instalação
 
 Clone o repositório:
 
@@ -32,7 +39,7 @@ Crie um ambiente virtual (opcional, recomendado):
 ```bash
 python -m venv venv
 venv\Scripts\activate     # Windows
-source venv/bin/activate    # Linux/Mac
+source venv/bin/activate  # Linux/Mac
 ```
 
 Instale as dependências:
@@ -41,7 +48,9 @@ Instale as dependências:
 pip install -r requirements.txt
 ```
 
-## Uso
+---
+
+## ▶️ Uso
 
 ```bash
 python main.py
@@ -49,10 +58,37 @@ python main.py
 
 A interface gráfica será aberta com abas para **Clientes**, **Produtos**, **Orçamentos** e **Consulta de Orçamentos**.
 
-## Estrutura
+---
 
-- `main.py` → código principal  
-- `requirements.txt` → dependências  
-- `pedidos.db` → banco SQLite (gerado automaticamente)  
-- `*.xlsx` / `*.pdf` → arquivos exportados  
+## 🗂️ Estrutura do Projeto
+
+```
+sistema-orcamentos/
+│
+├── main.py              # Código principal
+├── requirements.txt     # Dependências do projeto
+├── pedidos.db           # Banco SQLite (gerado automaticamente)
+├── docs/
+│   └── images/          # Prints de tela (opcional)
+└── arquivos_exportados/ # PDFs e planilhas .xlsx geradas
+```
+
+---
+
+## 📸 Interface
+
+### Tela de Clientes
+<img width="1677" height="965" alt="image" src="https://github.com/user-attachments/assets/69945def-8a5c-46a0-bf45-ba9377eea2da" />
+
+
+### Tela de Produtos
+<img width="1679" height="972" alt="image" src="https://github.com/user-attachments/assets/64821873-58b2-491f-b243-265c946b724f" />
+
+
+### Tela de Orçamentos
+<img width="1676" height="969" alt="image" src="https://github.com/user-attachments/assets/40edfe8e-5ab7-4a93-af85-6f62e011f55f" />
+
+
+---
+
 


### PR DESCRIPTION
**feat(ui): separar tela de edição de orçamentos da tela de criação**

- Cria aba exclusiva `Editar Orçamento` separada da aba de novos orçamentos  
- Evita confusão entre criação e atualização de registros  
- Adiciona suporte a edição completa (status, observações, descontos etc.)  
- Mantém layout e integração com funções existentes (`finalizar_pedido`, `gerar_pdf_orcamento`)  
- Atualiza fluxo do botão "Abrir Orçamento" → agora abre em nova aba