### PR TITLE
Alterando o delete na aba empresas

### DIFF
--- a/main.py
+++ b/main.py
@@ -2346,8 +2346,9 @@ class SistemaPedidos:
             return
         try:
             for item in sel:
-                vals = self.tree_empresas.item(item, 'values')
-                self.cursor.execute("DELETE FROM empresas WHERE id=?", (vals[0],))
+                empresa_id = self.tree_empresas.item(item, 'tags')[0]
+                self.cursor.execute("DELETE FROM empresas WHERE id=?", (empresa_id,))
+
             self.conn.commit()
             self.carregar_empresas()
             self.carregar_combos_pedido()


### PR DESCRIPTION
# 🧾 Resumo do PR — Correção da exclusão de empresas

## Descrição
Corrige o problema na função `excluir_empresa`, que impedia a exclusão de empresas cadastradas.

## Problema
A exclusão não funcionava porque o código usava o valor exibido na Treeview (`values[0]`, que correspondia ao nome da empresa) em vez do ID real da tabela `empresas`.
Assim, a query `DELETE FROM empresas WHERE id=?` não encontrava registros válidos.

## Solução Implementada
- Alterado o método `excluir_empresa` para recuperar o **ID correto** da empresa usando `item["tags"][0]` em vez de `item["values"][0]`.
- Mantida a confirmação de exclusão e o recarregamento da lista (`carregar_empresas`).
- Garantido que a exclusão atualize também os combos dependentes de empresas (`carregar_combos_pedido`).

## Código Corrigido
```python
def excluir_empresa(self):
    sel = self.tree_empresas.selection()
    if not sel:
        messagebox.showwarning("Atenção", "Selecione uma ou mais empresas para excluir.")
        return

    if not messagebox.askyesno("Confirmação", f"Deseja realmente excluir {len(sel)} empresa(s)?"):
        return

    try:
        for item in sel:
            empresa_id = self.tree_empresas.item(item, "tags")[0]
            self.cursor.execute("DELETE FROM empresas WHERE id=?", (empresa_id,))

        self.conn.commit()
        self.carregar_empresas()
        self.carregar_combos_pedido()
        messagebox.showinfo("Sucesso", f"{len(sel)} empresa(s) excluída(s) com sucesso!")
    except Exception as e:
        messagebox.showerror("Erro", f"Erro ao excluir empresa: {e}")
```

## Impacto
- A funcionalidade de exclusão de empresas agora funciona corretamente.
- Melhora a consistência da base de dados e evita registros órfãos.
